### PR TITLE
feat(garage): Implement better display of variables for Drive page

### DIFF
--- a/src/carconnectivity_plugins/webui/ui/templates/garage/vehicle.html
+++ b/src/carconnectivity_plugins/webui/ui/templates/garage/vehicle.html
@@ -201,7 +201,7 @@
                 {% for child in vehicle.drives.children %}
                 {% if child.enabled and child.id not in ['commands'] %}
                 <tr>
-                  <td>{{child.id}}</td>
+                  <td>{{format_attribute_name(child.id)}}</td>
                   <td>{{format_cc_element(child, '', linebreak=true)}}</td>
                 </tr>
                 {% endif %}


### PR DESCRIPTION
Adds a simple battery tab:

<img width="1011" height="385" alt="image" src="https://github.com/user-attachments/assets/96ee3c9a-e842-488c-a69c-53d8855f612c" />

