### PR TITLE
Add a light/dark theme switcher

### DIFF
--- a/src/carconnectivity_plugins/webui/ui/static/js/theme.js
+++ b/src/carconnectivity_plugins/webui/ui/static/js/theme.js
@@ -1,0 +1,67 @@
+// Light/dark theme switcher for the CarConnectivity web UI.
+// Plain browser JavaScript: no imports, no build step, classic <script src>.
+// Uses the native Bootstrap 5.3 color modes (data-bs-theme on <html>).
+// Choice is one of "light", "dark", "auto" (auto follows the OS preference)
+// and is persisted in localStorage under "cc-theme". An inline head script
+// applies the stored choice before paint; this module wires the switcher and
+// keeps "auto" in sync with live OS preference changes.
+
+(function () {
+  var KEY = "cc-theme";
+
+  function stored() {
+    try { return localStorage.getItem(KEY); } catch (e) { return null; }
+  }
+
+  function systemPrefersDark() {
+    return !!(window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches);
+  }
+
+  function resolve(choice) {
+    if (choice === "light" || choice === "dark") { return choice; }
+    return systemPrefersDark() ? "dark" : "light";
+  }
+
+  function apply(choice) {
+    document.documentElement.setAttribute("data-bs-theme", resolve(choice));
+  }
+
+  function reflect(choice) {
+    var items = document.querySelectorAll("[data-cc-theme]");
+    for (var i = 0; i < items.length; i++) {
+      items[i].classList.toggle("active", items[i].getAttribute("data-cc-theme") === choice);
+    }
+  }
+
+  window.ccTheme = {
+    get: function () { return stored() || "auto"; },
+    set: function (choice) {
+      try { localStorage.setItem(KEY, choice); } catch (e) {}
+      apply(choice);
+      reflect(choice);
+    },
+    apply: apply
+  };
+
+  // Keep "auto" following the OS preference while the page is open.
+  if (window.matchMedia) {
+    try {
+      window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", function () {
+        if ((stored() || "auto") === "auto") { apply("auto"); }
+      });
+    } catch (e) {}
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    var choice = stored() || "auto";
+    apply(choice);
+    reflect(choice);
+    var items = document.querySelectorAll("[data-cc-theme]");
+    for (var i = 0; i < items.length; i++) {
+      items[i].addEventListener("click", function (ev) {
+        ev.preventDefault();
+        window.ccTheme.set(this.getAttribute("data-cc-theme"));
+      });
+    }
+  });
+})();

--- a/src/carconnectivity_plugins/webui/ui/templates/base.html
+++ b/src/carconnectivity_plugins/webui/ui/templates/base.html
@@ -5,10 +5,22 @@
   <title>{% block title %}{% endblock %} - CarConnectivity</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <script>
+    // Set the Bootstrap color mode before the stylesheets apply to avoid a flash.
+    (function () {
+      try {
+        var c = localStorage.getItem('cc-theme') || 'auto';
+        var dark = (c === 'dark') || (c === 'auto' && window.matchMedia
+                    && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        document.documentElement.setAttribute('data-bs-theme', dark ? 'dark' : 'light');
+      } catch (e) {}
+    })();
+  </script>
   <link rel="stylesheet" href="{{ url_for('static', filename='css/bootstrap.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
   <script src="{{ url_for('static', filename='js/bootstrap.bundle.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/theme.js') }}"></script>
   <script>
     $(function () {
         $('[data-toggle="tooltip"]').tooltip()
@@ -63,7 +75,7 @@
               <li><a class="dropdown-item" href="{{sublink.url}}">{{sublink.text}}</a></li>
               {% else %}
               <li class="nav-item dropend">
-                <a class="nav-link dropdown-toggle text-dark" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                <a class="nav-link dropdown-toggle text-body" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                   {{sublink.text}}
                 </a>
                 <ul class="dropdown-menu">
@@ -80,6 +92,16 @@
           {% endfor %}
         </ul>
         <div class="navbar-nav ms-auto">
+          <div class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Toggle theme">
+              Theme
+            </a>
+            <ul class="dropdown-menu dropdown-menu-end">
+              <li><a class="dropdown-item" href="#" data-cc-theme="light">Light</a></li>
+              <li><a class="dropdown-item" href="#" data-cc-theme="dark">Dark</a></li>
+              <li><a class="dropdown-item" href="#" data-cc-theme="auto">Auto</a></li>
+            </ul>
+          </div>
           {% if current_user.is_authenticated %}
           <a href="{{ url_for('logout') }}" class="nav-item nav-link">Logout {{ current_user.get_id() }}</a>
           {% else %}
@@ -113,7 +135,7 @@
             <p>CarConnectivity</p>
           </div>
           <div class="col-md-6 text-md-end">
-            <a href="{{ url_for('about') }}" class="text-dark">About</a>
+            <a href="{{ url_for('about') }}" class="text-body">About</a>
           </div>
         </div>
       </footer>


### PR DESCRIPTION
## What

Adds an optional light/dark theme to the web UI, using the native Bootstrap 5.3 color modes already bundled (`data-bs-theme` on `<html>`). No new dependency, no build step.

A small menu in the top navigation bar lets the user pick **Light**, **Dark** or **Auto**. Auto follows the operating system preference (`prefers-color-scheme`) and updates live if the user switches their OS theme while the page is open. The choice is remembered in `localStorage`.

## How it works

- A short blocking script in `<head>` reads the saved choice and sets `data-bs-theme` before the stylesheets apply, so there is no flash of the wrong theme on load.
- `static/js/theme.js` wires the navbar switcher, persists the choice, resolves `auto` against the OS preference, and keeps `auto` in sync with live OS changes. It exposes a small `window.ccTheme` helper.
- Two links that were hard-coded `text-dark` (the footer About link and the nested dropdown toggle) become `text-body` so they stay readable in dark mode. The navbar itself stays `bg-dark` in both themes.

Dynamic data and the log views (which already use a fixed dark box) are unaffected.

## Notes

- Fully backwards compatible: with no stored choice the default is `auto`, which on a light OS renders exactly as today.
- Tables, cards, forms, dropdowns and alerts all restyle automatically thanks to Bootstrap color modes.

Happy to tweak the switcher placement, labels, or the default.